### PR TITLE
Enable AsyncAPI support

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -17,7 +17,7 @@ on:
     type: [docker_build_push]
 
 env:
-  REGISTRY_IMAGE: swaggerapi/swagger-ui
+  REGISTRY_IMAGE: vgaidarji/swagger-ui
 
 jobs:
   inputs:
@@ -44,6 +44,7 @@ jobs:
 
 
 
+
   build:
     name: Build & Push SwaggerUI platform specific Docker images
     runs-on: ubuntu-latest
@@ -51,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # linux/amd64 is already built by Jenkins
+          - linux/amd64
           - linux/arm/v6
           - linux/arm64
           - linux/386
@@ -67,13 +68,19 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_SB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_SB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_SB_PASSWORD }}
 
       - name: Build and push by digest
@@ -82,6 +89,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
           provenance: false
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
@@ -125,17 +133,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_SB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_SB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_SB_PASSWORD }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:${{ needs.inputs.outputs.docker_tag }} \
-            ${{ env.REGISTRY_IMAGE }}:${{ needs.inputs.outputs.docker_tag }} \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,19 +1,39 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
-    <link rel="stylesheet" type="text/css" href="index.css" />
-    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
-  </head>
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+  <link rel="stylesheet" type="text/css" href="index.css" />
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="SwaggerUIMultifold" />
+  <!-- use latest 5.x tag from https://github.com/swagger-api/swagger-editor/tags -->
+  <link rel="stylesheet" href="//unpkg.com/swagger-editor@5.0.0-alpha.98/dist/swagger-editor.css" />
+</head>
 
-  <body>
-    <div id="swagger-ui"></div>
-    <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
-    <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-    <script src="./swagger-initializer.js" charset="UTF-8"> </script>
-  </body>
+<body>
+  <div id="swagger-ui"></div>
+  <!-- use latest version from https://unpkg.com/browse/swagger-ui-dist@5.18.2/ -->
+  <script src="//unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-bundle.js"></script>
+  <script src="//unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-standalone-preset.js"></script>
+
+  <!-- <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script> -->
+  <script>
+    ui = SwaggerUIBundle({});
+    // expose SwaggerUI React globally for SwaggerEditor to use
+    window.React = ui.React;
+  </script>
+
+  <!-- use latest 5.x tag from https://github.com/swagger-api/swagger-editor/tags -->
+  <script src="//unpkg.com/swagger-editor@5.0.0-alpha.98/dist/umd/swagger-editor.js"></script>
+
+  <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+  <!-- add additional plugins via initializer script -->
+  <!-- see docker/configurator/translator.js -->
+  <script src="./swagger-initializer.js" charset="UTF-8"> </script>
+</body>
 </html>

--- a/docker/configurator/translator.js
+++ b/docker/configurator/translator.js
@@ -31,7 +31,7 @@ const defaultBaseConfig = {
     }
   },
   plugins: {
-    value: `[\n  SwaggerUIBundle.plugins.DownloadUrl\n]`,
+    value: `[\n  SwaggerUIBundle.plugins.DownloadUrl,\n  SwaggerEditor.plugins.EditorContentType,\n  SwaggerEditor.plugins.EditorPreviewAsyncAPI,\n  SwaggerEditor.plugins.EditorPreviewApiDesignSystems,\n  SwaggerEditor.plugins.SwaggerUIAdapter\n]`,
     schema: {
       type: "array",
       base: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swagger-ui",
-  "version": "5.18.2",
+  "version": "5.18.2-async-api-support",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swagger-ui",
-      "version": "5.18.2",
+      "version": "5.18.2-async-api-support",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-ui",
-  "version": "5.18.2",
+  "version": "5.18.2-async-api-support",
   "main": "./dist/swagger-ui.js",
   "module": "./dist/swagger-ui-es-bundle-core.js",
   "exports": {

--- a/test/unit/docker/translator.js
+++ b/test/unit/docker/translator.js
@@ -106,7 +106,11 @@ describe("docker: env translator", function() {
       SwaggerUIStandalonePreset
     ],
     plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
+      SwaggerUIBundle.plugins.DownloadUrl,
+      SwaggerEditor.plugins.EditorContentType,
+      SwaggerEditor.plugins.EditorPreviewAsyncAPI,
+      SwaggerEditor.plugins.EditorPreviewApiDesignSystems,
+      SwaggerEditor.plugins.SwaggerUIAdapter
     ],
     layout: "StandaloneLayout",
     queryConfigEnabled: false,
@@ -212,7 +216,11 @@ describe("docker: env translator", function() {
         SwaggerUIStandalonePreset
       ],
       plugins: [
-        SwaggerUIBundle.plugins.DownloadUrl
+        SwaggerUIBundle.plugins.DownloadUrl,
+        SwaggerEditor.plugins.EditorContentType,
+        SwaggerEditor.plugins.EditorPreviewAsyncAPI,
+        SwaggerEditor.plugins.EditorPreviewApiDesignSystems,
+        SwaggerEditor.plugins.SwaggerUIAdapter
       ],
       layout: "StandaloneLayout",
       queryConfigEnabled: false,
@@ -313,7 +321,11 @@ describe("docker: env translator", function() {
         SwaggerUIStandalonePreset
       ],
       plugins: [
-        SwaggerUIBundle.plugins.DownloadUrl
+        SwaggerUIBundle.plugins.DownloadUrl,
+        SwaggerEditor.plugins.EditorContentType,
+        SwaggerEditor.plugins.EditorPreviewAsyncAPI,
+        SwaggerEditor.plugins.EditorPreviewApiDesignSystems,
+        SwaggerEditor.plugins.SwaggerUIAdapter
       ],
       queryConfigEnabled: false,
       configUrl: "/wow",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Enabled [AsyncAPI](https://www.asyncapi.com/) support. 
Used approach described in 
- https://github.com/swagger-api/swagger-ui/issues/6632#issuecomment-1195653604
- https://github.com/swagger-api/swagger-editor/tree/next?tab=readme-ov-file#utilizing-preview-plugins-via-unpkgcom.

Updated the version from the latest `master` branch from original repository. Will be releasing from fork with custom version which matches original repo version tag + `-async-api-support` to distinguish the versions and publish to personal Dockerhub account.

To deploy custom image, rebase on top of the master from original repository, create new tag, trigger the build&deploy action manually using the new custom tag and "latest" tag for docker version.

`Build & Push SwaggerUI multi platform Docker image`
![image](https://github.com/user-attachments/assets/1bbc0733-7fae-4f40-a20a-13ec3e86a828)

Requires `DOCKERHUB_SB_PASSWORD` secret to be configured in repo settings.
`DOCKERHUB_SB_USERNAME` - cannot be used in secrets as in my case GitHub username matches Dockerhub username and if I use it as a secret variable it gets sanitized in logs and docker push fails.
`DOCKERHUB_SB_USERNAME` is regular variable in repo settings.

Also, customized merged manifest push to dockerhub based on https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners. For some reason original repo approach doesn't work for me.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Swagge-UI doesn't come with AsyncAPI plugins enabled by default. Swagger-Editor has support for AsyncAPI and there's a way to enable these plugins for Swagger-UI.

https://hub.docker.com/repository/docker/vgaidarji/swagger-ui - forked image location.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by customizing dev-helpers/index.html and providing async API definition yaml file.
Use custom image in Helm chart, deploy and test with async api definition yaml on any repository (will test separately).

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
